### PR TITLE
Bug Fix

### DIFF
--- a/wikihowpy/__init__.py
+++ b/wikihowpy/__init__.py
@@ -247,9 +247,9 @@ class Article:
 
     def get(self):
         return {
-            'url': self._url,
+            'url': self.url,
             'title': self.title,
-            'intro': self._intro,
+            'intro': self.intro,
             'n_steps': self.n_steps,
             'steps': self.steps,
             'summary': self.summary,


### PR DESCRIPTION
`random_article().get()['url']` was giving http://www.wikihow.com/Special:Randomizer as output instead of article URL.

This bug is now fixed.